### PR TITLE
[BUG] Passed slices to get_electron_density in all cases

### DIFF
--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -891,7 +891,8 @@ function get_electron_density(
     kwargs...)
 
     if typeof(snaps) <: Integer
-        return get_electron_density(xp.expname,snaps,xp.expdir;kwargs...)
+        return get_electron_density(xp.expname,snaps,xp.expdir;
+		slicex=slicex,slicey=slicey,slicez=slicez,kwargs...)
     elseif typeof(snaps) <: AbstractVector{<:Integer}
         mx, my, mz = get_dims(slicex, slicey, slicez, xp.mesh)
         var = Array{Float32}(undef, mx, my, mz, length(snaps))


### PR DESCRIPTION
The slices in electron density were not being passed when calling snap with an integer.