### PR TITLE
Re-structure `get_var` and add keyword arguments

### DIFF
--- a/src/BifrostTools.jl
+++ b/src/BifrostTools.jl
@@ -25,9 +25,6 @@ export change_snap_resolution, duplicate_xz_plane
 export make_uniform_axes
 
 export arr_ffile
-export heatmap_xy
-export heatmap_xz
-export heatmap_yz
 
 export get_eostable
 export get_expieos_err
@@ -120,6 +117,6 @@ export poissonud
 export divB_clean_ud
 export divB_clean_du
 
-
+export destaggeroperation
 
 end # module BifrostTools

--- a/src/BifrostTools.jl
+++ b/src/BifrostTools.jl
@@ -18,13 +18,8 @@ include("eos_tables.jl")
 include("unit_conversion.jl")
 
 # Exports
-export squeeze
 export read_params
-export load_snapdata
-export load_auxdata
-export load_snapvariable
-export load_auxvariable
-export get_var, get_staggered_var, get_snap_numbers, get_electron_density
+export get_var, get_snap_numbers, get_electron_density
 export change_snap_resolution, duplicate_xz_plane
 
 export make_uniform_axes

--- a/src/experiment.jl
+++ b/src/experiment.jl
@@ -48,9 +48,12 @@ struct BifrostExperiment
                                     findall=true)
 
         # Get some snap-independent parameters
-        params_file = string(expdir, "/", expname, "_", string(snaps[1], pad=3),
-                             ".idl"
-                             )
+        params_file = string(
+            joinpath(expdir,expname),
+            "_", lpad(snaps[1],3,"0"),
+            ".idl"
+        )
+
         params = read_params(params_file)
         snapsize, num_vars = get_snapsize_and_numvars(params)
    

--- a/src/experiment.jl
+++ b/src/experiment.jl
@@ -51,7 +51,7 @@ struct BifrostExperiment
         params_file = string(expdir, "/", expname, "_", string(snaps[1], pad=3),
                              ".idl"
                              )
-        params = br_read_params(params_file)
+        params = read_params(params_file)
         snapsize, num_vars = get_snapsize_and_numvars(params)
    
         new(mesh, expname, expdir, sort(snaps), snapsize, length(snaps),

--- a/src/experiment.jl
+++ b/src/experiment.jl
@@ -52,10 +52,10 @@ struct BifrostExperiment
                              ".idl"
                              )
         params = br_read_params(params_file)
-        snapsize, num_primary_vars = get_snapsize_and_numvars(params)
+        snapsize, num_vars = get_snapsize_and_numvars(params)
         
         new(mesh, expname, expdir, sort(snaps), snapsize, length(snaps),
-            num_primary_vars
+            num_vars[1]
             )
     end
 end     

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -248,10 +248,10 @@ function get_var(
     # data
     if nsnaps == 1
         data = get_var(
-            string(basename_isnap, file_ext), 
+            string(basename_isnap, file_ext),
             params, 
-            varnr, 
-            args...
+            varnr; 
+            kwargs...
             )
     else
         data = get_var(
@@ -259,8 +259,8 @@ function get_var(
             snap,
             params,
             varnr, 
-            file_ext, 
-            args...
+            file_ext;
+            kwargs...
             )
     end
     # -------------------------------------------------------------------------
@@ -329,11 +329,13 @@ precision snapshot by default.
 function get_var(
     filename       ::String,
     params         ::Dict{String,String},
-    varnr          ::Integer,
+    varnr          ::Integer
+    ;
     precision      ::DataType=Float32,
     slicex         ::AbstractVector{<:Integer}=Int[],
     slicey         ::AbstractVector{<:Integer}=Int[],
-    slicez         ::AbstractVector{<:Integer}=Int[]
+    slicez         ::AbstractVector{<:Integer}=Int[],
+    kwargs...
     )
     datadims = 3 # 3 spatial dimensions and 1 variable dimension
     snapsize = get_snapsize(params)
@@ -387,11 +389,13 @@ function get_var(
     snaps    ::AbstractVector{<:Integer},
     params   ::Dict{String, String},
     varnr    ::Integer,
-    file_ext ::String,
-    precision::DataType=Float32;
+    file_ext ::String
+    ;
+    precision::DataType=Float32,
     slicex   ::AbstractVector{<:Integer}=Int[],
     slicey   ::AbstractVector{<:Integer}=Int[],
-    slicez   ::AbstractVector{<:Integer}=Int[]
+    slicez   ::AbstractVector{<:Integer}=Int[],
+    kwargs...
     )
     # Get spatial size
     mx, my, mz = get_snapsize(params, slicex, slicey, slicez)
@@ -409,10 +413,10 @@ function get_var(
             tmp_file,
             params_local,
             varnr,
-            precision,
-            slicex,
-            slicey,
-            slicez
+            precision=precision,
+            slicex=slicex,
+            slicey=slicey,
+            slicez=slicez
             )
         
         # Need manual call to run garbage collector within threads

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -34,7 +34,7 @@ end
 
 
 """
-    br_load_snapdata(
+    get_snap(
         expname::String,
         snap   ::Int,
         expdir ::String,
@@ -61,30 +61,22 @@ Variables of `snapdata`:
 Warning:
     variables in code units.ts
 """
-function br_load_snapdata(
+function get_snap(
     expname  ::String,
     snap     ::Int,
     expdir   ::String,
     precision::DataType=Float32
     )
-    datadims = 4 # 3 spatial dimensions and 1 variable dimension
     # Parse filenames
     basename = string(expdir, "/", expname, "_$(lpad(snap,3,"0"))")
     idl_filename = string(basename, ".idl")
     snap_filename = string(basename, ".snap")
     params = br_read_params(idl_filename)
-    
-    snapsize, numvars, _ = get_snapsize_and_numvars(params)
-
-    file = open(snap_filename)
-    # Use Julia standard-library memory-mapping to extract file values
-    snapdata = mmap(file, Array{precision, 4}, (snapsize..., numvars))
-    close(file)
-    return snapdata, params
-end # function br_load_snapdata
+    get_snap(snap_filename, params, precision)
+end
 
 """
-    br_load_snapdata(
+    get_snap(
         file_name::String,
         params   ::Dict{String,String}
         )
@@ -109,7 +101,7 @@ Variables of `snapdata`:
 Warning:
     variables in code units.
 """
-function br_load_snapdata(
+function get_snap(
     file_name::String,
     params   ::Dict{String,String},
     precision::DataType=Float32
@@ -126,7 +118,7 @@ function br_load_snapdata(
 end # function br_load_snapdata
 
 """
-    br_load_auxdata(
+    get_aux(
         file_name::String,
         params   ::Dict{String,String}
     )
@@ -134,7 +126,7 @@ Reads Bifrost *.aux binary file using memory-mapping. The returned
 `auxdata` array will have dimensions (mx,my,mz,nvars) where nvars is the
 number of aux-variables. Assumes single floating point precision by default.
 """
-function br_load_auxdata(
+function get_aux(
     file_name::String,
     params   ::Dict{String,String},
     precision::DataType=Float32

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -400,7 +400,7 @@ function get_time(
     end
 
     if :units in keys(kwargs)
-        convert_timeunits!(var, params)
+        var = convert_timeunits(var, params)
     end
     
     return var

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -383,6 +383,7 @@ function get_time(
     snap   ::Union{<:Integer, AbstractVector{<:Integer}},
     expdir ::String 
     ;
+    units::String="si",
     kwargs...
     )
     nsnaps = length(snap)
@@ -399,7 +400,7 @@ function get_time(
         end
     end
 
-    if :units in keys(kwargs)
+    if units != "code"
         var = convert_timeunits(var, params)
     end
     

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -71,7 +71,7 @@ function get_snap(
     basename = string(expdir, "/", expname, "_$(lpad(snap,3,"0"))")
     idl_filename = string(basename, ".idl")
     snap_filename = string(basename, ".snap")
-    params = br_read_params(idl_filename)
+    params = read_params(idl_filename)
     get_snap(snap_filename, params, precision)
 end
 
@@ -236,7 +236,7 @@ function get_var(
     )
     nsnaps = length(snap)
     basename, basename_isnap = get_basename(expname, snap, expdir)
-    params = br_read_params(string(basename_isnap, ".idl"))
+    params = read_params(string(basename_isnap, ".idl"))
 
     if variable == "t"
         # The special case of getting the snapshot time
@@ -407,7 +407,7 @@ function get_var(
         # !! Create thread-local variables to avoid race conditions !!
         isnap_local = lpad(snap,3,"0")
         idl_file_local = string(basename, "_", isnap_local, ".idl")
-        params_local = br_read_params(idl_file_local)        
+        params_local = read_params(idl_file_local)
         tmp_file = string(basename, "_", isnap_local, file_ext)
 
         var[:,:,:,i] .= get_var(
@@ -445,7 +445,7 @@ function get_time(
         for (i,snap) in enumerate(snap)
             isnap = lpad(snap,3,"0")
             idl_file = string(filename_prefix, isnap, file_ext)
-            params = br_read_params(idl_file) 
+            params = read_params(idl_file)
             time = parse(Float64, params["t"])
             var[i] = time
         end
@@ -640,17 +640,17 @@ function destagger(
     if variable in ("r", "e", "tg", "p")
         return data # nothing to do, already cell centred
     elseif variable in ("px", "bx")
-        return br_xup(data)
+        return xup(data)
     elseif variable in ("py", "by")
-        return br_yup(data)        # not sure about the minus sign
+        return yup(data)
     elseif variable in ("pz", "bz")
-        return br_zup(data)        # not sure about the minus sign
+        return zup(data)
     elseif variable in ("ex", "ix")
-        return br_yup(br_zup(data)) # not 100% sure about this operation
+        return yup(zup(data)) # not 100% sure about this operation
     elseif variable in ("ey", "iy")
-        return br_zup(br_xup(data)) # not 100% sure about this operation
+        return zup(xup(data)) # not 100% sure about this operation
     elseif variable in ("ez", "iz")
-        return br_xup(br_yup(data)) # not 100% sure about this operation
+        return xup(yup(data)) # not 100% sure about this operation
     else
         error("Destaggering of variable $variable is not implemented.")
     end

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -240,6 +240,7 @@ function get_var(
     args...
     ;
     precision::DataType=Float32,
+    squeeze::Bool=true,
     kwargs...
     )
 
@@ -256,10 +257,14 @@ function get_var(
 
     # Check if user wants data to be destaggered. If so we have to
     # call get_and_destagger_var. If not, we may call get_var
-    if :destagger in kwarg_keys && kwarg_values.destagger
+    destagger = try kwarg_values.destagger
+    catch
+        false
+    end
+    if destagger
         # Check if destagger-operation is passed as a keyword-argument.
-        # If not, use defualt operation corresponding to the requested
-        # variable if available. If not throw error,
+        # If not, use default operation corresponding to the requested
+        # variable.
         if :destaggeroperation in kwarg_keys
             get_function = get_and_destagger_var
         elseif variable in keys(destaggeroperation)
@@ -318,17 +323,15 @@ function get_var(
     #
     # ORIENTATION: Rotate coordinate system
     #
-    if :rotate_about_x in kwarg_keys && kwarg_values.rotate_about_x
-        data = rotate(data, variable, "x")
-    end
+    try data = rotate(data, variable, kwarg_values.rotate_about)
+    catch end
 
     # CONCATENATION: Concatenate vector to 4D array
-    if :stack in kwarg_keys && kwarg_values.stack
-       data = stack(data)
-    end
+    try kwarg_values.stack ? data = stack(data) : nothing
+    catch end
 
     # SQUEEZE: Drop empty dimensions
-    if length(snaps) == 1 && :squeeze in kwarg_keys && kwarg_values.squeeze
+    if squeeze && length(data) == 1
         data = data[1]
     end
 

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -273,6 +273,15 @@ function get_var(
     kwarg_keys = keys(kwargs)
     kwarg_values = values(kwargs)
     # -------------------------------------------------------------------------
+
+    #
+    # UNITS: Scale from code units to something else
+    # 
+    #   If multiple snapshots: Assumes the same conversion factor for all
+    #
+    if :units in kwarg_keys
+        data = convert_units(data, variable, params, kwarg_values.units)
+    end
     #
     # Add more kwargs here
     #

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -299,6 +299,13 @@ function get_var(
     end
 
     #
+    # ORIENTATION: Rotate coordinate system
+    #
+    if :rotate_about_x in kwarg_keys && kwarg_values.rotate_about_x
+        data = rotate(data, variable, "x")
+    end
+
+    #
     # Add more kwargs here
     #
     # -------------------------------------------------------------------------
@@ -641,6 +648,39 @@ function destagger(
         return br_xup(br_yup(data)) # not 100% sure about this operation
     else
         error("Destaggering of variable $variable is not implemented.")
+    end
+end
+
+
+"""
+    rotate(
+        data         ::AbstractArray,
+        variable     ::String,
+        rotation_axis::String,
+        )
+Rotate the data about an `rotation_axis`.
+"""
+function rotate(
+    data         ::AbstractArray,
+    variable     ::String,
+    rotation_axis::String,
+    )
+    xcomponents = ("px", "bx", "ex", "ix")
+    ycomponents = ("py", "by", "ey", "iy")
+    zcomponents = ("pz", "bz", "ez", "iz")
+
+    if variable in ("r", "p", "tg")
+        return data # Scalar fields, do nothing
+    else
+        if rotation_axis == "x"
+            if variable in xcomponents
+                return data
+            elseif variable in ycomponents || variable in zcomponents
+                return -data
+            end
+        else
+            error("Rotation about $rotation_axis-axis is not implemented")
+        end
     end
 end
 

--- a/src/read_params_snap_aux.jl
+++ b/src/read_params_snap_aux.jl
@@ -1,13 +1,4 @@
-const primary_vars = Dict(
-    "r" => 1,
-    "px" => 2, 
-    "py" => 3, 
-    "pz" => 4, 
-    "e" => 5, 
-    "bx" => 6, 
-    "by" => 7, 
-    "bz" => 8,  
-)
+
 
 """
     br_read_params(file_name::String)
@@ -162,30 +153,6 @@ function br_load_auxdata(
         return auxdata
     end
 end # function br_load_auxdata
-
-"""
-    get_variable_offset_in_file(
-        precision::DataType,
-        snapsize::Tuple{Integer, Integer, Integer},
-        varnr   ::Integer
-        )
-Given the precision and size of a snapshot, find the offset for reading the
-variable with index `varnr` directly from file. Offset given in number of bytes.
-"""
-function get_variable_offset_in_file(
-    precision::DataType,
-    snapsize::Tuple{Integer, Integer, Integer},
-    varnr   ::Integer
-    )
-    if precision == Float32
-        bytes_per_value = 4
-    elseif precision == Float64
-        bytes_per_value = 8
-    end 
-    values_per_variable = snapsize[1]*snapsize[2]*snapsize[3]
-    offset = bytes_per_value*values_per_variable*(varnr - 1)
-    return offset
-end
 
 
 """

--- a/src/stagger_operators.jl
+++ b/src/stagger_operators.jl
@@ -1561,27 +1561,27 @@ function dzdn(
 end
 
 """
-    yupzup(args...)
+    yupzup(data, args...)
 For destagering variables at cell edges, in particular the x-axis.
 """
-function yupzup(args...)
-    yup(zup(args...))
+function yupzup(data, args...)
+    yup(zup(data, args...), args...)
 end
 
 
 """
-    zupxup(args...)
+    zupxup(data, args...)
 For destagering variables at cell edges, in particular the y-axis.
 """
-function zupxup(args...)
-    zup(xup(args...))
+function zupxup(data, args...)
+    zup(xup(data, args...), args...)
 end
 
 
 """
-    xupyup(args...)
+    xupyup(data, args...)
 For destagering variables at cell edges, in particular the z-axis.
 """
-function xupyup(args...)
-    xup(yup(args...))
+function xupyup(data, args...)
+    xup(yup(data, args...), args...)
 end

--- a/src/stagger_operators.jl
+++ b/src/stagger_operators.jl
@@ -1560,4 +1560,28 @@ function dzdn(
     end
 end
 
+"""
+    yupzup(args...)
+For destagering variables at cell edges, in particular the x-axis.
+"""
+function yupzup(args...)
+    yup(zup(args...))
+end
 
+
+"""
+    zupxup(args...)
+For destagering variables at cell edges, in particular the y-axis.
+"""
+function zupxup(args...)
+    zup(xup(args...))
+end
+
+
+"""
+    xupyup(args...)
+For destagering variables at cell edges, in particular the z-axis.
+"""
+function xupyup(args...)
+    xup(yup(args...))
+end

--- a/src/unit_conversion.jl
+++ b/src/unit_conversion.jl
@@ -143,10 +143,11 @@ end
 
 Converts snapshot time to seconds
 """
-function convert_timeunits!(
+function convert_timeunits(
     t     ::Union{AbstractArray, AbstractFloat},
     params::Dict{String,String}
-    )     ::Float64
-    t *= params["u_t"]
+    )
+
+    t *= parse(Float64, params["u_t"])
 end
 

--- a/src/unit_conversion.jl
+++ b/src/unit_conversion.jl
@@ -46,12 +46,13 @@ function convert_units(
     params  ::Dict{String,String},
     units   ::String,
     )
-    if units == "SI"
+    if lowercase(units) == "si"
         return code_to_SI(data, variable, params)
-    elseif units == "cgs"
+    elseif lowercase(units) == "cgs"
         return code_to_cgs(data, variable, params)
-    elseif units == "code"
+    elseif lowercase(units) == "code"
         # Do nothing
+        nothing
     else
         throw(ErrorException("Unit conversion '$units' does not exits"))
     end

--- a/src/unit_conversion.jl
+++ b/src/unit_conversion.jl
@@ -1,105 +1,135 @@
 """
 Script for converting from Bifrost's simulation units to cgs or si units. 
-Consult https://github.com/ITA-Solar/Bifrost/blob/develop/IDL/util/br_make_fits.pro
+Based on https://github.com/ITA-Solar/Bifrost/blob/develop/IDL/util/br_make_fits.pro
 """
 
-# Simulation units
-const params = Dict(
-        "u_l" => 1f8,
-        "u_t" => 1f2,
-        "u_r" => 1f-7,
-        "u_u" => 1f6,
-        "u_p" => 1f5,
-        "u_e" => 1f5,
-        "u_B" => Float32(1121)
-        )
-
-# Converts from simulation units to cgs units
-const cgs_params = Dict(
-        # pressure
-        "p" => params["u_p"],
-        # gas density
-        "r" => params["u_r"],
-        # momentum
-        "px" => params["u_r"]*params["u_u"],
-        "py" => params["u_r"]*params["u_u"],
-        "pz" => params["u_r"]*params["u_u"],
-        # energy
-        "e" => params["u_e"],
-        # B-field
-        "bx"  => params["u_B"],
-        "by"  => params["u_B"],
-        "bz"  => params["u_B"]
-        )
-
-# Converts from simulation units to cgs units
-const si_params = Dict(
-        # pressure
-        "p" => params["u_p"]*1f-1,
-        # gas density
-        "r" => params["u_r"]*1f3,
-        # momentum
-        "px" => params["u_r"]*params["u_u"]*1f1,
-        "py" => params["u_r"]*params["u_u"]*1f1,
-        "pz" => params["u_r"]*params["u_u"]*1f1,
-        # energy
-        "e" => params["u_e"]*1f-1,
-        # B-field
-        "bx"  => params["u_B"]*1f-4,
-        "by"  => params["u_B"]*1f-4,
-        "bz"  => params["u_B"]*1f-4
-        )
 
 """
-    convert_units!(
-        snapvariable, 
-        variable::String, 
-        unit_conversion::String
-        )
-
-Converts the units of `snapvariable` from simulation units to 'si' or 'cgs'
-units
+    cgs_to_SI_conversion_factors
+Factors for converting some physical quantities from cgs-units to SI-units.
 """
-function convert_units!(
-    snapvariable::AbstractArray, 
-    variable::String, 
-    unit_conversion::String
+const cgs_to_SI_conversion_factors = Dict(
+    # Pressure:    g/s^2/cm * 1f-3 kg/g * 1f2 cm/m = 1f-1 kg/s^2/m
+    "p"  => 1f-1,
+    # Gas density: g/cm^3 * 1f-3 kg/g * 1f6 cm^3/m^3 = 1f3 kg/m^3
+    "r"  => 1f3,
+    # Momentum:    g/cm^2/s * 1f-3 kg/g * 1f4 cm^2/m^2 = 1f1 kg/m^2/s
+    "px" => 1f1,
+    "py" => 1f1,
+    "pz" => 1f1,
+    # Energy:     erg/cm^3 * 1f-7 J/erg * 1f6 cm^3/m = 1f-1 J/m^3
+    "e"  => 1f-1,
+    # Magnetic field: G * 1f-4 T/G = 1f-4 T
+    "bx" => 1f-4,
+    "by" => 1f-4,
+    "bz" => 1f-4,
+    # Electric field: g*cm/s^2/Fr * 1f-3 kg/g * 1f-2 m/cm * 1f-1 Fr/C 
+    #                   = 1f-6 kg*m/s^2/C
+    "ex" => 1f-6,
+    "ey" => 1f-6,
+    "ez" => 1f-6,
     )
 
-    if unit_conversion=="cgs"
-        if variable != "tg"
-            snapvariable .*= cgs_params[variable]
-        end
-        
-    elseif unit_conversion=="si"
-        if variable != "tg"
-            snapvariable .*= si_params[variable]
-        end
-    
+
+"""
+    convert_units(
+        data    ::AbstractArray,
+        variable::String,
+        params  ::Dict{String,String},
+        units   ::String,
+        )
+Convert the `data` from code `units` to someting else.
+"""
+function convert_units(
+    data    ::AbstractArray,
+    variable::String,
+    params  ::Dict{String,String},
+    units   ::String,
+    )
+    if units == "SI"
+        return code_to_SI(data, variable, params)
+    elseif units == "cgs"
+        return code_to_cgs(data, variable, params)
+    elseif units == "code"
+        # Do nothing
     else
-        throw(ErrorException("Unit conversion '$unit_conversion' does not exits"))
+        throw(ErrorException("Unit conversion '$units' does not exits"))
     end
 end
 
-function convert_units(
-    snapvariable::AbstractArray, 
-    variable::String, 
-    unit_conversion::String
-    )::Array{Float32, 3}
+"""
+    code_to_SI(
+        data    ::AbstractArray,
+        variable::String,
+        params  ::Dict{String,String},
+    )
+Convert the `data` from code units to SI units.
+"""
+function code_to_SI(
+    data    ::AbstractArray,
+    variable::String,
+    params  ::Dict{String,String},
+    )
+    tmp = code_to_cgs(data, variable, params)
+    return cgs_to_SI(tmp, variable)
+end
 
-    if unit_conversion=="cgs"
-        if variable != "tg"
-            snapvariable = snapvariable .* cgs_params[variable]
-        end
-        
-    elseif unit_conversion=="si"
-        if variable != "tg"
-            snapvariable = snapvariable .* si_params[variable]
-        end
-    
+"""
+    code_to_cgs(
+        data    ::AbstractArray,
+        variable::String,
+        params  ::Dict{String,String},
+    )
+Convert the `data` from code-units to cgs-units.
+"""
+function code_to_cgs(
+    data    ::AbstractArray,
+    variable::String,
+    params  ::Dict{String,String},
+    )
+    if variable == "r"                       # Density
+        return  data * parse(Float32, params["u_r"])
+    elseif variable == "e"                   # Energy
+         return data * parse(Float32, params["u_e"])
+    elseif variable == "tg"                  # Gas temperature
+        return data # nothing to do
+    elseif variable == "p"                   # Pressure
+         return data * parse(Float32, params["u_p"])
+    elseif variable in ("px", "py", "pz")    # Momentum
+         return data*parse(Float32, params["u_r"])*parse(Float32,params["u_u"])
+    elseif variable in ("bx", "by", "bz")    # Magnetic field
+         return data * parse(Float32, params["u_B"])
+    #elseif variable in ("ix", "iy", "iz")    # Current density
+        # not implemented yet
+    elseif variable in ("ex", "ey", "ez")    # Electric field
+         return data*parse(Float32, params["u_u"])*parse(Float32,params["u_B"])
     else
-        throw(ErrorException("Unit conversion '$unit_conversion' does not exits"))
-        snapvariable = snapvariable .* 0f0
+        throw(ErrorException(
+            "Conversion to cgs-units of variable $variable is not implemented."
+            ))
+    end
+end
+
+"""
+    cgs_to_SI(
+        data    ::AbstractArray,
+        variable::String,
+        params  ::Dict{String,String},
+    )
+Convert the `data` from cgs-units to SI-units.
+"""
+function cgs_to_SI(
+    data    ::AbstractArray,
+    variable::String,
+    )
+    if variable == "tg" # Temperature: Kelvin -> Kelvin
+        return data # nothing to do
+    elseif variable in keys(cgs_to_SI_conversion_factors)
+        return data * cgs_to_SI_conversion_factors[variable]
+    else
+        throw(ErrorException(
+            "Conversion to SI-units of variable $variable is not implemented."
+            ))
     end
 end
 

--- a/src/unit_conversion.jl
+++ b/src/unit_conversion.jl
@@ -103,13 +103,19 @@ function convert_units(
     end
 end
 
+
 """
-    convert_time(t::AbstractFloat)
+    convert_timeunits!(
+    t     ::AbstractArray,
+    params::Dict{String,String}
+    )     ::Float64
 
 Converts snapshot time to seconds
 """
-function convert_snaptime(t::AbstractFloat)::Float64
-
-    t*params["u_t"]
-
+function convert_timeunits!(
+    t     ::Union{AbstractArray, AbstractFloat},
+    params::Dict{String,String}
+    )     ::Float64
+    t *= params["u_t"]
 end
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,10 +2,116 @@
     get_snapsize_and_numvars(
         params::Dict{String,String},
     )
-Returns snapsize (nx, ny, nz), number of primary variables and number of
+Returns snapsize (mx, my, mz), number of primary variables and number of
 auxiliary variables, given the snapshot-parameters.
 """
 function get_snapsize_and_numvars(
+    params::Dict{String,String},
+    )
+    return get_snapsize(params), get_numvars(params)
+end
+
+
+"""
+    get_snapsize(
+        params::Dict{String,String},
+    )
+Returns snapsize (mx, my, mz) given the snapshot-parameters.
+"""
+function get_snapsize(
+    params::Dict{String,String},
+    )
+    mx = parse(Int, params["mx"])
+    my = parse(Int, params["my"])
+    mz = parse(Int, params["mz"])
+    snapsize::Tuple{Int64, Int64, Int64} = mx, my, mz
+    return snapsize 
+end
+"""
+    get_snapsize(
+        params::Dict{String,String},
+        slicex::AbstractVector{<:Integer},
+        slicey::AbstractVector{<:Integer},
+        slicez::AbstractVector{<:Integer}
+    )
+Returns snapsize (mx, my, mz) given the snapshot-parameters.
+"""
+function get_snapsize(
+    params::Dict{String,String},
+    slicex::AbstractVector{<:Integer},
+    slicey::AbstractVector{<:Integer},
+    slicez::AbstractVector{<:Integer}
+    )
+    if isempty(slicex)
+        mx = parse(Int, params["mx"])
+    else
+        mx = length(slicex)
+    end
+    if isempty(slicey)
+        my = parse(Int, params["my"])
+    else
+        my = length(slicey)
+    end
+    if isempty(slicez)
+        mz = parse(Int, params["mz"])
+    else
+        mz = length(slicez)
+    end
+    return mx, my, mz
+end
+"""
+    get_snapsize(
+        mesh::BifrostMesh,
+    )
+Returns snapsize (mx, my, mz) given a Bifrost-mesh.
+"""
+function get_snapsize(
+    mesh::BifrostMesh,
+    )
+    return (mesh.mx, mesh.my, mesh.mz)
+end
+"""
+    get_snapsize(
+        mesh::BifrostMesh,
+        slicex::AbstractVector{<:Integer},
+        slicey::AbstractVector{<:Integer},
+        slicez::AbstractVector{<:Integer}
+    )
+Returns snapsize (mx, my, mz) given a Bifrost-mesh.
+"""
+function get_snapsize(
+    mesh::BifrostMesh,
+    slicex::AbstractVector{<:Integer},
+    slicey::AbstractVector{<:Integer},
+    slicez::AbstractVector{<:Integer}
+    )    
+    if isempty(slicex)
+        mx = mesh.mx
+    else
+        mx = length(slicex)
+    end
+    if isempty(slicey)
+        my = mesh.my
+    else
+        my = length(slicey)
+    end
+    if isempty(slicez)
+        mz = mesh.mz
+    else
+        mz = length(slicez)
+    end
+    return mx, my, mz
+end
+
+
+"""
+    get_numvars(
+        params::Dict{String,String},
+    )
+Returns number of primary variables and number of
+auxiliary variables, given the snapshot-parameters.
+"""
+function get_numvars(
     params::Dict{String,String},
     )
     if parse(Int, params["do_mhd"]) == 1
@@ -14,17 +120,17 @@ function get_snapsize_and_numvars(
         numvars = 5
     end
     numauxvars::Int64 = length(split(params["aux"]))
-    
-    mx = parse(Int, params["mx"])
-    my = parse(Int, params["my"])
-    mz = parse(Int, params["mz"])
-    snapsize::Tuple{Int64, Int64, Int64} = mx, my, mz
-    return snapsize, numvars, numauxvars
+    return numvars, numauxvars
 end
 
-
 """
-    br_find_snap_numbers
+    get_snap_numbers(
+        expdir::String, 
+        expname::String="none"
+        ;
+        findall::Bool=false, 
+        filenames::Vector{String}=String[]
+        )
 
 Finds all files in the format 'expname_XXX.snap' in the experiment directory
 `exp_dir`, and returns a vector of the snapshots XXX. If `expname` is not
@@ -72,56 +178,55 @@ function get_snap_numbers(
 end
 
 
-function get_dims(slicex::AbstractVector{<:Integer},
-                  slicey::AbstractVector{<:Integer},
-                  slicez::AbstractVector{<:Integer},
-                  params::Dict{String, String})
-
-    if isempty(slicex)
-        mx = parse(Int, params["mx"])
+"""
+    get_varnr_and_file_ext(
+        params::Dict{String,String},
+        variable::String
+        )
+Given the snapshot `params` and desired `variable`, return
+its index in the binary file, as well as the extension of this file.
+(Either ".aux" or ".snap").
+"""
+function get_varnr_and_file_extension(
+    params  ::Dict{String,String},
+    variable::String,
+    )
+    if variable in keys(primary_vars)
+        file_ext = ".snap"
+        varnr = primary_vars[variable]
+    elseif variable in split(params["aux"])
+        file_ext = ".aux"
+        indices = findall(x -> x == variable, split(params["aux"]))
+        if length(indices) > 1  
+            error("Multiple matches for given aux-variable name.")
+        elseif length(indices) == 0
+            throw(ErrorException("Auxiliary variable not found in file."))
+        end
+        varnr =  indices[1]
     else
-        mx = length(slicex)
+        throw(ErrorException("Variable $variable does not exist"))
     end
-
-    if isempty(slicey)
-        my = parse(Int, params["my"])
-    else
-        my = length(slicey)
-    end
-
-    if isempty(slicez)
-        mz = parse(Int, params["mz"])
-    else
-        mz = length(slicez)
-    end
-
-    return mx, my, mz
-
+    return varnr, file_ext
 end
 
-function get_dims(slicex::AbstractVector{<:Integer},
-    slicey::AbstractVector{<:Integer},
-    slicez::AbstractVector{<:Integer},
-    mesh::BifrostMesh)
 
-    if isempty(slicex)
-        mx = mesh.mx
-    else
-        mx = length(slicex)
-    end
 
-    if isempty(slicey)
-        my = mesh.my
-    else
-        my = length(slicey)
-    end
-
-    if isempty(slicez)
-        mz = mesh.mz
-    else
-        mz = length(slicez)
-    end
-
-    return mx, my, mz
-
+"""
+    get_basename(
+        expname ::String,
+        snap    ::Union{<:Integer, AbstractVector{<:Integer}},
+        expdir  ::String,
+        )
+Return the basename of snapshots in the experiment `expname`, located in the 
+directory `expdir`. Also return the filename (withou file extension) of the 
+first snapshot of the experiment.
+"""
+function get_basename(
+    expname ::String,
+    snap    ::Union{<:Integer, AbstractVector{<:Integer}},
+    expdir  ::String,
+    )
+    isnap = lpad(snap[1],3,"0")
+    basename =  joinpath(expdir, expname)
+    return  basename, string(basename, "_", isnap)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -269,3 +269,12 @@ function get_basename(
     basename =  joinpath(expdir, expname)
     return  basename, string(basename, "_", isnap)
 end
+
+
+"""
+    addtokwargs(;kwargs...)
+Add keyword-arguments to your `Base.Pairs` of kwargs.
+"""
+function addtokwargs(;kwargs...)
+    kwargs
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,20 @@
 """
+    primary_vars
+The primary variables and their order of storage for primary variables in a 
+Bifrost .snap binary file.
+"""
+const primary_vars = Dict(
+    "r"  => 1,
+    "px" => 2,
+    "py" => 3,
+    "pz" => 4,
+    "e"  => 5,
+    "bx" => 6,
+    "by" => 7,
+    "bz" => 8,
+)
+
+"""
     get_snapsize_and_numvars(
         params::Dict{String,String},
     )
@@ -209,6 +225,29 @@ function get_varnr_and_file_extension(
     return varnr, file_ext
 end
 
+"""
+    get_variable_offset_in_file(
+        precision::DataType,
+        snapsize::Tuple{Integer, Integer, Integer},
+        varnr   ::Integer
+        )
+Given the precision and size of a snapshot, find the offset for reading the
+variable with index `varnr` directly from file. Offset given in number of bytes.
+"""
+function get_variable_offset_in_file(
+    precision::DataType,
+    snapsize::Tuple{Integer, Integer, Integer},
+    varnr   ::Integer
+    )
+    if precision == Float32
+        bytes_per_value = 4
+    elseif precision == Float64
+        bytes_per_value = 8
+    end
+    values_per_variable = snapsize[1]*snapsize[2]*snapsize[3]
+    offset = bytes_per_value*values_per_variable*(varnr - 1)
+    return offset
+end
 
 
 """

--- a/src/write_params_snap_aux.jl
+++ b/src/write_params_snap_aux.jl
@@ -28,7 +28,7 @@ function change_snap_resolution(
     ;
     filename::String="out.snap"
     )
-    primaries, params = load_snapdata(xp.expname, isnap, xp.expdir)
+    primaries, params = get_snap(xp.expname, isnap, xp.expdir)
     snapsize, numvars, _ = get_snapsize_and_numvars(params)
     change_snap_resolution(primaries, xp.mesh, numvars, 
                                 new_x, new_y, new_z, itp_bc;
@@ -48,7 +48,7 @@ function change_snap_resolution(
     )
     params_filename = snapname[1:end-4]*"idl"
     params = read_params(params_filename)
-    primaries = load_snapdata(snapname, params)
+    primaries = get_snap(snapname, params)
     snapsize, numvars, _ = get_snapsize_and_numvars(params)
     mesh = BifrostMesh(meshname)
     change_snap_resolution(primaries, mesh, numvars,
@@ -200,7 +200,7 @@ function duplicate_xz_plane(
     ;
     filename::String="out.snap"
     )
-    primaries, params = load_snapdata(xp.expname, isnap, xp.expdir)
+    primaries, params = get_snap(xp.expname, isnap, xp.expdir)
     duplicate_xz_plane(primaries, ny; filename=filename)
 end
 
@@ -212,7 +212,7 @@ function duplicate_xz_plane(
     )
     params_filename = snapname[1:end-4]*"idl"
     params = read_params(params_filename)
-    primaries = load_snapdata(snapname, params)
+    primaries = get_snap(snapname, params)
     duplicate_xz_plane(primaries, ny; filename=filename)
 end 
 


### PR DESCRIPTION
The use of `get_var` remains the same, but I've tried to simplify its implementation. There is now a readable "main" `get_var` method  -- which takes either single or multiple snapshots -- that calls more specific `get_var`-methods and finally applies operations to the data according to arbitrary keyword-arguments. It should be easy to extend the functionality of `get_var` by adding more keywords and corresponding implementation.

Note that applying operations to the data through `get_var` keywords will make it return a _copy_ of the snapshot-variable, not a _memory mapping_.

Notable changes:
1.  **Deleted** `br_load_snapvariable` and `br_load_auxvariable` because `get_var` should not be noticeably slower.
2. **Added** unit conversion as an option in `get_var`. Set the keyword-argument `units` to either `"cgs"` or `"SI"`. Unit conversion vil now use snapschot-specific conversion factors. 
3. **Added** destaggering as an option in `get_var`. Set the keyword-argument `destagger=true`.
4. **Added** rotation of the vector-fields as an option in `get_var`. Set the keyword-argument `rotation_about_x=true`. It should be easy to extend the function `rotate` to allow for arbitrary rotation around arbitrary axes.
5. **Changed** the name of `br_load_snapdata` and `br_load_auxdata` to `get_snap` and `get_aux`, respectively. 
6. **Replaced** `get_snapvarnr` and `get_auxvarnr` with `get_varnr_and_file_extension`.
7. **Replaced** `get_dims` with `get_snapsize`
8. `get_snapsize_and_numvars` returns two tuples instead of one tuple and two integers.
9. **Moved** `get_variable_offset_in_file` and `primary_vars` to `utils.jl`.

The code has been tested locally.